### PR TITLE
Removed deprecated "yarn next export" command for static pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: "export"
+};
+
+module.exports = nextConfig;

--- a/render.yaml
+++ b/render.yaml
@@ -13,7 +13,7 @@ services:
 # - type: web
 #   name: nextjs-static
 #   env: static
-#   buildCommand: yarn; yarn build; yarn next export
+#   buildCommand: yarn; yarn build
 #   staticPublishPath: out
 #   pullRequestPreviewsEnabled: true     # optional
 #   envVars:


### PR DESCRIPTION
I couldn't deploy the example because of the following error message:

The "next export" command has been removed in favor of "output: export" in next.config.js. Learn more: https://nextjs.org/docs/advanced-features/static-html-export.

So I removed this build command and added the necessary next.config.js with the "output: export" key/value pair, as per Next.JS convention.